### PR TITLE
MCP server + watcher integration

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -34,14 +34,13 @@ tracing-subscriber = { workspace = true }
 
 # Serialization
 serde = { workspace = true }
-schemars = "0.8"
 toml = { workspace = true }
 
 # Progress indicators
 indicatif = { workspace = true }
 
 # MCP protocol support
-rmcp = { version = "0.6", features = ["server"] }
+rmcp = { version = "0.8", features = ["server"] }
 
 # File system utilities
 glob = { workspace = true }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -34,6 +34,7 @@ tracing-subscriber = { workspace = true }
 
 # Serialization
 serde = { workspace = true }
+schemars = "0.8"
 toml = { workspace = true }
 
 # Progress indicators

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -163,9 +163,11 @@ fn default_limit() -> Option<usize> {
 
 #[tool_router]
 impl CodeSearchMcpServer {
-    #[tool(description = "Search for code entities semantically using natural language queries. \
+    #[tool(
+        description = "Search for code entities semantically using natural language queries. \
                           Returns similar functions, classes, and other code constructs with full \
-                          details including content, documentation, and signature.")]
+                          details including content, documentation, and signature."
+    )]
     async fn search_code(
         &self,
         Parameters(request): Parameters<SearchCodeRequest>,
@@ -186,17 +188,13 @@ impl CodeSearchMcpServer {
                 )
             })?;
 
-        let query_embedding = embeddings
-            .into_iter()
-            .next()
-            .flatten()
-            .ok_or_else(|| {
-                McpError::new(
-                    ErrorCode::INTERNAL_ERROR,
-                    "Failed to generate embedding".to_string(),
-                    None,
-                )
-            })?;
+        let query_embedding = embeddings.into_iter().next().flatten().ok_or_else(|| {
+            McpError::new(
+                ErrorCode::INTERNAL_ERROR,
+                "Failed to generate embedding".to_string(),
+                None,
+            )
+        })?;
 
         // Parse entity type filter
         let entity_type = request
@@ -217,7 +215,11 @@ impl CodeSearchMcpServer {
             .search_similar(query_embedding, limit, Some(filters))
             .await
             .map_err(|e| {
-                McpError::new(ErrorCode::INTERNAL_ERROR, format!("Search failed: {e}"), None)
+                McpError::new(
+                    ErrorCode::INTERNAL_ERROR,
+                    format!("Search failed: {e}"),
+                    None,
+                )
             })?;
 
         // Batch fetch from Postgres
@@ -317,9 +319,7 @@ impl ServerHandler for CodeSearchMcpServer {
         Ok(InitializeResult {
             protocol_version: ProtocolVersion::default(),
             capabilities: ServerCapabilities {
-                tools: Some(rmcp::model::ToolsCapability {
-                    list_changed: None,
-                }),
+                tools: Some(rmcp::model::ToolsCapability { list_changed: None }),
                 resources: Some(ResourcesCapability {
                     subscribe: None,
                     list_changed: None,
@@ -348,9 +348,7 @@ impl ServerHandler for CodeSearchMcpServer {
                     uri: "codesearch://repo/info".to_string(),
                     name: "Repository Information".to_string(),
                     title: None,
-                    description: Some(
-                        "Current repository metadata and configuration".to_string(),
-                    ),
+                    description: Some("Current repository metadata and configuration".to_string()),
                     mime_type: Some("application/json".to_string()),
                     size: None,
                     icons: None,

--- a/crates/watcher/src/lib.rs
+++ b/crates/watcher/src/lib.rs
@@ -45,7 +45,9 @@ pub use debouncer::{BatchProcessor, EventDebouncer};
 pub use events::{
     ChangeType, DebouncedEvent, DiffStats, EntityId, FileChange, FileMetadata, LineRange,
 };
-pub use git::{BranchChange, BranchWatcher, GitDetector, GitRepository};
+pub use git::{
+    BranchChange, BranchWatcher, FileDiffChangeType, FileDiffStatus, GitDetector, GitRepository,
+};
 pub use ignore::{CompositeLanguageFilter, IgnoreFilter, LanguageFilter};
 pub use watcher::{FileWatcher, PollingWatcher};
 

--- a/migrations/003_add_last_indexed_commit.sql
+++ b/migrations/003_add_last_indexed_commit.sql
@@ -1,0 +1,10 @@
+-- Migration: Add last_indexed_commit tracking
+-- Enables efficient catch-up indexing by tracking the last git commit that was indexed
+
+ALTER TABLE repositories
+ADD COLUMN last_indexed_commit VARCHAR(40);
+
+CREATE INDEX IF NOT EXISTS idx_repositories_last_indexed_commit
+    ON repositories(last_indexed_commit) WHERE last_indexed_commit IS NOT NULL;
+
+COMMENT ON COLUMN repositories.last_indexed_commit IS 'Git commit SHA that was last indexed, used for catch-up indexing on server restart';


### PR DESCRIPTION
## Summary

Implements MCP server with stdio transport, integrated with real-time filesystem watcher. Closes #32.

- MCP `search_code` tool with entity details, filters, and embeddings
- MCP repository metadata resource (info endpoint)
- Watcher integration with signal handling (Ctrl+C)
- Catch-up indexing on server start

## Test plan

- [ ] Verify `codesearch serve` starts MCP server
- [ ] Test search_code tool with MCP client
- [ ] Verify file changes trigger re-indexing
- [ ] Test signal handling (Ctrl+C graceful shutdown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)