### PR TITLE
fix: migrate test git commands to git2 for worktree compatibility

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -75,3 +75,4 @@ accelerate = ["codesearch-embeddings/accelerate"]
 
 [dev-dependencies]
 tempfile = "3.14.0"
+git2 = { workspace = true }

--- a/crates/e2e-tests/Cargo.toml
+++ b/crates/e2e-tests/Cargo.toml
@@ -43,3 +43,6 @@ walkdir = "2.5"
 # SCIP parsing for graph validation
 scip = "0.6"
 protobuf = "3.7"
+
+# Git operations (use library instead of shell commands for worktree compatibility)
+git2 = "0.19"


### PR DESCRIPTION
## Summary
- Tests were using raw `git` shell commands which break in git worktrees because they operate on the enclosing repository instead of temp test dirs
- Migrated all tests to use git2 library for worktree-safe git operations

## Changes
- **indexer**: 3 tests using init/config/add/commit
- **cli**: helper function and 1 test  
- **e2e-tests**: git clone in graph_validation

## Test plan
- [ ] CI passes (fmt, clippy, tests)
- [ ] Verify tests work when run from a git worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)