### PR TITLE
docs: update documentation and fix Rust qualified name resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A semantic code search engine that indexes codebases using AST-based entity extr
 ## Quick Start
 
 **Prerequisites:**
-- Rust 1.70+
+- Rust 1.91+
 - Docker and Docker Compose
 - Jina API key (free tier available at jina.ai) or NVIDIA GPU for self-hosted embeddings
 
@@ -135,8 +135,8 @@ cargo build --workspace --all-targets
 
 **Test:**
 ```bash
-cargo test --workspace                              # Unit tests
-cargo test --package codesearch-e2e-tests -- --ignored  # E2E tests
+cargo test --workspace                                              # Unit tests
+cargo test --manifest-path crates/e2e-tests/Cargo.toml -- --ignored # E2E tests
 ```
 
 **Lint:**


### PR DESCRIPTION
## Summary

- Update CLAUDE.md with repository structure and worktree-per-issue workflow documentation
- Fix README.md: Rust version 1.70+ -> 1.91+, correct e2e test command
- Remove obsolete TSG section from new-language-onboarding.md
- Fix graph validation test to use commit hash instead of missing tag (1.0.100)
- Add RustResolutionContext struct to unify qualified name resolution across Rust handlers
- Fix import_map to normalize crate::/self::/super:: prefixes when resolving names

Related: #148 (CALLS/USES/IMPORTS relationship extraction still needs investigation)

## Test plan

- [x] cargo clippy --workspace passes
- [x] cargo test --workspace passes
- [x] graph_validation_test runs successfully (test result: ok)

🤖 Generated with [Claude Code](https://claude.com/claude-code)