### PR TITLE
Add TypeScript relationship extraction (CALLS, IMPORTS, REEXPORTS, USES)

### DIFF
--- a/crates/languages/src/common/js_ts_shared/handlers/function_handlers.rs
+++ b/crates/languages/src/common/js_ts_shared/handlers/function_handlers.rs
@@ -4,21 +4,28 @@ use crate::common::js_ts_shared::JavaScript;
 use crate::{define_handler, define_ts_family_handler};
 
 use super::common::{arrow_function_metadata, derive_function_expression_name, function_metadata};
+use super::relationships::extract_function_relationships;
 
 // JavaScript handlers
 define_handler!(JavaScript, handle_function_declaration_impl, "function", Function,
-    metadata: function_metadata);
+    metadata: function_metadata,
+    relationships: extract_function_relationships);
 define_handler!(JavaScript, handle_arrow_function_impl, "function", Function,
-    metadata: arrow_function_metadata);
+    metadata: arrow_function_metadata,
+    relationships: extract_function_relationships);
 define_handler!(JavaScript, handle_function_expression_impl, "function", Function,
     name_ctx_fn: derive_function_expression_name,
-    metadata: function_metadata);
+    metadata: function_metadata,
+    relationships: extract_function_relationships);
 
 // TypeScript and TSX handlers
 define_ts_family_handler!(handle_ts_function_declaration_impl, handle_tsx_function_declaration_impl, "function", Function,
-    metadata: function_metadata);
+    metadata: function_metadata,
+    relationships: extract_function_relationships);
 define_ts_family_handler!(handle_ts_arrow_function_impl, handle_tsx_arrow_function_impl, "function", Function,
-    metadata: arrow_function_metadata);
+    metadata: arrow_function_metadata,
+    relationships: extract_function_relationships);
 define_ts_family_handler!(handle_ts_function_expression_impl, handle_tsx_function_expression_impl, "function", Function,
     name_ctx_fn: derive_function_expression_name,
-    metadata: function_metadata);
+    metadata: function_metadata,
+    relationships: extract_function_relationships);

--- a/crates/languages/src/common/js_ts_shared/handlers/mod.rs
+++ b/crates/languages/src/common/js_ts_shared/handlers/mod.rs
@@ -30,6 +30,7 @@ pub(crate) mod function_handlers;
 pub(crate) mod method_handlers;
 pub(crate) mod module_handlers;
 pub(crate) mod property_handlers;
+pub(crate) mod relationships;
 pub(crate) mod typescript_handlers;
 pub(crate) mod variable_handlers;
 

--- a/crates/languages/src/common/js_ts_shared/handlers/module_handlers.rs
+++ b/crates/languages/src/common/js_ts_shared/handlers/module_handlers.rs
@@ -3,15 +3,92 @@
 //! Each JS/TS file is treated as its own module, establishing the containment
 //! hierarchy for entities defined within the file.
 
-use crate::common::js_ts_shared::JavaScript;
-use crate::{define_handler, define_ts_family_handler};
+#![deny(warnings)]
+#![deny(clippy::unwrap_used)]
+#![deny(clippy::expect_used)]
 
-use super::common::derive_module_name_from_ctx;
+use crate::common::entity_building::{
+    build_entity, CommonEntityComponents, EntityDetails, ExtractionContext,
+};
+use crate::common::module_utils;
+use crate::common::{node_to_text, require_capture_node};
+use codesearch_core::entities::{EntityMetadata, EntityType, Language, SourceLocation, Visibility};
+use codesearch_core::entity_id::generate_entity_id;
+use codesearch_core::error::Result;
+use codesearch_core::CodeEntity;
 
-// JavaScript module handler
-define_handler!(JavaScript, handle_module_impl, "program",
-    module_name_fn: derive_module_name_from_ctx);
+use super::relationships::extract_module_relationships;
 
-// TypeScript and TSX module handlers
-define_ts_family_handler!(handle_ts_module_impl, handle_tsx_module_impl, "program",
-    module_name_fn: derive_module_name_from_ctx);
+/// Handle JavaScript module as a Module entity
+pub(crate) fn handle_module_impl(ctx: &ExtractionContext) -> Result<Vec<CodeEntity>> {
+    handle_module_for_language(ctx, Language::JavaScript)
+}
+
+/// Handle TypeScript module as a Module entity
+pub(crate) fn handle_ts_module_impl(ctx: &ExtractionContext) -> Result<Vec<CodeEntity>> {
+    handle_module_for_language(ctx, Language::TypeScript)
+}
+
+/// Handle TSX module as a Module entity
+pub(crate) fn handle_tsx_module_impl(ctx: &ExtractionContext) -> Result<Vec<CodeEntity>> {
+    // TSX is TypeScript + JSX, so we use Language::TypeScript
+    handle_module_for_language(ctx, Language::TypeScript)
+}
+
+/// Common module handling for all JS/TS languages
+fn handle_module_for_language(
+    ctx: &ExtractionContext,
+    language: Language,
+) -> Result<Vec<CodeEntity>> {
+    let module_node = require_capture_node(ctx.query_match, ctx.query, "program")?;
+
+    // Extract module name from file path
+    let name = module_utils::derive_module_name(ctx.file_path);
+
+    // Build qualified name from file path
+    let qualified_name =
+        module_utils::derive_qualified_name(ctx.file_path, ctx.source_root, ctx.repo_root, ".");
+
+    // Build path_entity_identifier (repo-relative path for import resolution)
+    let path_entity_identifier =
+        module_utils::derive_path_entity_identifier(ctx.file_path, ctx.repo_root, ".");
+
+    // Generate entity ID
+    let file_path_str = ctx.file_path.to_string_lossy();
+    let entity_id = generate_entity_id(ctx.repository_id, &file_path_str, &qualified_name);
+
+    // Get location
+    let location = SourceLocation::from_tree_sitter_node(module_node);
+
+    // Create components
+    let components = CommonEntityComponents {
+        entity_id,
+        repository_id: ctx.repository_id.to_string(),
+        name,
+        qualified_name,
+        path_entity_identifier: Some(path_entity_identifier),
+        parent_scope: None,
+        file_path: ctx.file_path.to_path_buf(),
+        location,
+    };
+
+    // Extract relationships (imports and reexports)
+    let relationships = extract_module_relationships(module_node, ctx.source);
+
+    // Build the entity
+    let entity = build_entity(
+        components,
+        EntityDetails {
+            entity_type: EntityType::Module,
+            language,
+            visibility: Some(Visibility::Public),
+            documentation: None,
+            content: node_to_text(module_node, ctx.source).ok(),
+            metadata: EntityMetadata::default(),
+            signature: None,
+            relationships,
+        },
+    )?;
+
+    Ok(vec![entity])
+}

--- a/crates/languages/src/common/js_ts_shared/handlers/relationships.rs
+++ b/crates/languages/src/common/js_ts_shared/handlers/relationships.rs
@@ -1,0 +1,620 @@
+//! Relationship extraction for JavaScript and TypeScript
+//!
+//! This module provides functions for extracting IMPORTS, REEXPORTS, USES, and CALLS
+//! relationships from JavaScript and TypeScript source code.
+
+#![deny(warnings)]
+#![deny(clippy::unwrap_used)]
+#![deny(clippy::expect_used)]
+
+use crate::common::entity_building::ExtractionContext;
+use codesearch_core::entities::{
+    EntityRelationshipData, ReferenceType, SourceLocation, SourceReference,
+};
+use std::collections::HashSet;
+use tree_sitter::Node;
+
+// =============================================================================
+// Primitive type filtering
+// =============================================================================
+
+/// TypeScript/JavaScript primitive types to skip in type reference extraction
+const TS_PRIMITIVE_TYPES: &[&str] = &[
+    "string",
+    "number",
+    "boolean",
+    "void",
+    "null",
+    "undefined",
+    "never",
+    "any",
+    "unknown",
+    "object",
+    "symbol",
+    "bigint",
+    // Built-in generic types
+    "Array",
+    "Promise",
+    "Map",
+    "Set",
+    "Record",
+    "Partial",
+    "Required",
+    "Readonly",
+    "Pick",
+    "Omit",
+    "Exclude",
+    "Extract",
+    "NonNullable",
+    "ReturnType",
+    "Parameters",
+    "InstanceType",
+];
+
+/// Check if a type name is a primitive/built-in type
+fn is_primitive_type(name: &str) -> bool {
+    TS_PRIMITIVE_TYPES.contains(&name)
+}
+
+// =============================================================================
+// Import extraction
+// =============================================================================
+
+/// Extract import path from a string literal node (removing quotes)
+fn extract_import_path(string_node: Node, source: &str) -> Option<String> {
+    let text = &source[string_node.byte_range()];
+    // Remove quotes (both single and double)
+    let path = text
+        .trim_start_matches(['"', '\''])
+        .trim_end_matches(['"', '\'']);
+    if path.is_empty() {
+        None
+    } else {
+        Some(path.to_string())
+    }
+}
+
+/// Derive a qualified name from an import path and imported name
+fn derive_import_qualified_name(import_path: &str, name: &str) -> String {
+    // Convert relative path to module name
+    // "./utils" -> "utils"
+    // "../lib/helpers" -> "lib.helpers"
+    // "@scope/package" -> "@scope/package"
+    let module_part = import_path
+        .trim_start_matches("./")
+        .trim_start_matches("../")
+        .replace('/', ".");
+
+    // Remove file extension if present
+    let module_part = module_part
+        .trim_end_matches(".ts")
+        .trim_end_matches(".tsx")
+        .trim_end_matches(".js")
+        .trim_end_matches(".jsx");
+
+    format!("{module_part}.{name}")
+}
+
+/// Extract imports from a module node
+///
+/// Handles:
+/// - Named imports: `import { foo, bar } from './module'`
+/// - Default imports: `import Foo from './module'`
+/// - Namespace imports: `import * as Utils from './module'`
+/// - Side-effect imports are ignored: `import './module'`
+pub(crate) fn extract_imports(module_node: Node, source: &str) -> Vec<SourceReference> {
+    let mut imports = Vec::new();
+    let mut seen = HashSet::new();
+    let mut cursor = module_node.walk();
+
+    for child in module_node.children(&mut cursor) {
+        if child.kind() != "import_statement" {
+            continue;
+        }
+
+        // Get the source path (the string after 'from')
+        let Some(source_node) = child.child_by_field_name("source") else {
+            continue;
+        };
+        let Some(import_path) = extract_import_path(source_node, source) else {
+            continue;
+        };
+
+        // Get the import clause (contains the actual imports)
+        let Some(import_clause) = child
+            .children(&mut child.walk())
+            .find(|n| n.kind() == "import_clause")
+        else {
+            continue;
+        };
+
+        // Process each part of the import clause
+        let mut clause_cursor = import_clause.walk();
+        for clause_child in import_clause.children(&mut clause_cursor) {
+            match clause_child.kind() {
+                // Default import: import Foo from './module'
+                "identifier" => {
+                    let name = &source[clause_child.byte_range()];
+                    let qualified_name = derive_import_qualified_name(&import_path, name);
+                    if seen.insert(qualified_name.clone()) {
+                        if let Ok(source_ref) = SourceReference::builder()
+                            .target(qualified_name)
+                            .simple_name(name.to_string())
+                            .location(SourceLocation::from_tree_sitter_node(clause_child))
+                            .ref_type(ReferenceType::Import)
+                            .build()
+                        {
+                            imports.push(source_ref);
+                        }
+                    }
+                }
+                // Named imports: import { foo, bar as baz } from './module'
+                "named_imports" => {
+                    let mut specifier_cursor = clause_child.walk();
+                    for specifier in clause_child.children(&mut specifier_cursor) {
+                        if specifier.kind() != "import_specifier" {
+                            continue;
+                        }
+                        // Get the imported name (not the local alias)
+                        if let Some(name_node) = specifier.child_by_field_name("name") {
+                            let name = &source[name_node.byte_range()];
+                            let qualified_name = derive_import_qualified_name(&import_path, name);
+                            if seen.insert(qualified_name.clone()) {
+                                if let Ok(source_ref) = SourceReference::builder()
+                                    .target(qualified_name)
+                                    .simple_name(name.to_string())
+                                    .location(SourceLocation::from_tree_sitter_node(name_node))
+                                    .ref_type(ReferenceType::Import)
+                                    .build()
+                                {
+                                    imports.push(source_ref);
+                                }
+                            }
+                        }
+                    }
+                }
+                // Namespace import: import * as Utils from './module'
+                "namespace_import" => {
+                    // For namespace imports, the target is the module itself
+                    let module_name = import_path
+                        .trim_start_matches("./")
+                        .trim_start_matches("../")
+                        .replace('/', ".")
+                        .trim_end_matches(".ts")
+                        .trim_end_matches(".tsx")
+                        .trim_end_matches(".js")
+                        .trim_end_matches(".jsx")
+                        .to_string();
+
+                    if seen.insert(module_name.clone()) {
+                        // Get the alias name for simple_name
+                        let simple_name = clause_child
+                            .children(&mut clause_child.walk())
+                            .find(|n| n.kind() == "identifier")
+                            .map(|n| source[n.byte_range()].to_string())
+                            .unwrap_or_else(|| module_name.clone());
+
+                        if let Ok(source_ref) = SourceReference::builder()
+                            .target(module_name)
+                            .simple_name(simple_name)
+                            .location(SourceLocation::from_tree_sitter_node(clause_child))
+                            .ref_type(ReferenceType::Import)
+                            .build()
+                        {
+                            imports.push(source_ref);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    imports
+}
+
+// =============================================================================
+// Re-export extraction
+// =============================================================================
+
+/// Extract re-exports from a module node
+///
+/// Handles:
+/// - Named re-exports: `export { foo, bar } from './module'`
+/// - Star re-exports: `export * from './module'`
+/// - Namespace re-exports: `export * as Utils from './module'`
+pub(crate) fn extract_reexports(module_node: Node, source: &str) -> Vec<SourceReference> {
+    let mut reexports = Vec::new();
+    let mut seen = HashSet::new();
+    let mut cursor = module_node.walk();
+
+    for child in module_node.children(&mut cursor) {
+        if child.kind() != "export_statement" {
+            continue;
+        }
+
+        // Only process re-exports (those with a 'source' field)
+        let Some(source_node) = child.child_by_field_name("source") else {
+            continue;
+        };
+        let Some(export_path) = extract_import_path(source_node, source) else {
+            continue;
+        };
+
+        // Check for star export or namespace export
+        let has_star = child
+            .children(&mut child.walk())
+            .any(|n| n.kind() == "*" || &source[n.byte_range()] == "*");
+
+        let namespace_export = child
+            .children(&mut child.walk())
+            .find(|n| n.kind() == "namespace_export");
+
+        if let Some(ns_export) = namespace_export {
+            // Namespace re-export: export * as Utils from './module'
+            let module_name = export_path
+                .trim_start_matches("./")
+                .trim_start_matches("../")
+                .replace('/', ".")
+                .trim_end_matches(".ts")
+                .trim_end_matches(".tsx")
+                .trim_end_matches(".js")
+                .trim_end_matches(".jsx")
+                .to_string();
+
+            if seen.insert(module_name.clone()) {
+                let simple_name = ns_export
+                    .children(&mut ns_export.walk())
+                    .find(|n| n.kind() == "identifier")
+                    .map(|n| source[n.byte_range()].to_string())
+                    .unwrap_or_else(|| module_name.clone());
+
+                if let Ok(source_ref) = SourceReference::builder()
+                    .target(module_name)
+                    .simple_name(simple_name)
+                    .location(SourceLocation::from_tree_sitter_node(ns_export))
+                    .ref_type(ReferenceType::Reexport)
+                    .build()
+                {
+                    reexports.push(source_ref);
+                }
+            }
+        } else if has_star {
+            // Star re-export: export * from './module'
+            let module_name = export_path
+                .trim_start_matches("./")
+                .trim_start_matches("../")
+                .replace('/', ".")
+                .trim_end_matches(".ts")
+                .trim_end_matches(".tsx")
+                .trim_end_matches(".js")
+                .trim_end_matches(".jsx")
+                .to_string();
+
+            if seen.insert(module_name.clone()) {
+                if let Ok(source_ref) = SourceReference::builder()
+                    .target(module_name.clone())
+                    .simple_name(module_name)
+                    .location(SourceLocation::from_tree_sitter_node(child))
+                    .ref_type(ReferenceType::Reexport)
+                    .build()
+                {
+                    reexports.push(source_ref);
+                }
+            }
+        } else if let Some(export_clause) = child
+            .children(&mut child.walk())
+            .find(|n| n.kind() == "export_clause")
+        {
+            // Named re-exports: export { foo, bar } from './module'
+            let mut specifier_cursor = export_clause.walk();
+            for specifier in export_clause.children(&mut specifier_cursor) {
+                if specifier.kind() != "export_specifier" {
+                    continue;
+                }
+                // Get the exported name
+                if let Some(name_node) = specifier.child_by_field_name("name") {
+                    let name = &source[name_node.byte_range()];
+                    let qualified_name = derive_import_qualified_name(&export_path, name);
+                    if seen.insert(qualified_name.clone()) {
+                        if let Ok(source_ref) = SourceReference::builder()
+                            .target(qualified_name)
+                            .simple_name(name.to_string())
+                            .location(SourceLocation::from_tree_sitter_node(name_node))
+                            .ref_type(ReferenceType::Reexport)
+                            .build()
+                        {
+                            reexports.push(source_ref);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    reexports
+}
+
+// =============================================================================
+// Type reference extraction (USES)
+// =============================================================================
+
+/// Extract type references from a node (for USES relationships)
+///
+/// Walks the AST looking for type annotations and extracts referenced type names,
+/// filtering out primitive types.
+pub(crate) fn extract_type_references(node: Node, source: &str) -> Vec<SourceReference> {
+    let mut refs = Vec::new();
+    let mut seen = HashSet::new();
+    extract_type_refs_recursive(node, source, &mut refs, &mut seen);
+    refs
+}
+
+fn extract_type_refs_recursive(
+    node: Node,
+    source: &str,
+    refs: &mut Vec<SourceReference>,
+    seen: &mut HashSet<String>,
+) {
+    match node.kind() {
+        "type_identifier" => {
+            let name = &source[node.byte_range()];
+            if !is_primitive_type(name) && seen.insert(name.to_string()) {
+                if let Ok(source_ref) = SourceReference::builder()
+                    .target(name.to_string())
+                    .simple_name(name.to_string())
+                    .location(SourceLocation::from_tree_sitter_node(node))
+                    .ref_type(ReferenceType::TypeUsage)
+                    .build()
+                {
+                    refs.push(source_ref);
+                }
+            }
+        }
+        "generic_type" => {
+            // Extract base type name from generic: Foo<T> -> Foo
+            if let Some(name_node) = node.child_by_field_name("name") {
+                let name = &source[name_node.byte_range()];
+                if !is_primitive_type(name) && seen.insert(name.to_string()) {
+                    if let Ok(source_ref) = SourceReference::builder()
+                        .target(name.to_string())
+                        .simple_name(name.to_string())
+                        .location(SourceLocation::from_tree_sitter_node(name_node))
+                        .ref_type(ReferenceType::TypeUsage)
+                        .build()
+                    {
+                        refs.push(source_ref);
+                    }
+                }
+            }
+            // Also process type arguments
+            if let Some(type_args) = node.child_by_field_name("type_arguments") {
+                extract_type_refs_recursive(type_args, source, refs, seen);
+            }
+        }
+        _ => {
+            // Recurse into children
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                extract_type_refs_recursive(child, source, refs, seen);
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Function call extraction (CALLS)
+// =============================================================================
+
+/// Extract function calls from a node (for CALLS relationships)
+///
+/// Walks the AST looking for call expressions and extracts the callee names.
+pub(crate) fn extract_function_calls(node: Node, source: &str) -> Vec<SourceReference> {
+    let mut refs = Vec::new();
+    let mut seen = HashSet::new();
+    extract_calls_recursive(node, source, &mut refs, &mut seen);
+    refs
+}
+
+fn extract_calls_recursive(
+    node: Node,
+    source: &str,
+    refs: &mut Vec<SourceReference>,
+    seen: &mut HashSet<String>,
+) {
+    if node.kind() == "call_expression" {
+        if let Some(callee) = node.child_by_field_name("function") {
+            let (target, simple_name, location) = match callee.kind() {
+                // Bare function call: foo()
+                "identifier" => {
+                    let name = source[callee.byte_range()].to_string();
+                    (name.clone(), name, callee)
+                }
+                // Method call: obj.method() or Module.func()
+                "member_expression" => {
+                    let text = source[callee.byte_range()].to_string();
+                    // Get the property (method name) for simple_name
+                    let simple = callee
+                        .child_by_field_name("property")
+                        .map(|n| source[n.byte_range()].to_string())
+                        .unwrap_or_else(|| text.clone());
+                    (text, simple, callee)
+                }
+                // Other cases (like call().method())
+                _ => {
+                    let text = source[callee.byte_range()].to_string();
+                    (text.clone(), text, callee)
+                }
+            };
+
+            if seen.insert(target.clone()) {
+                if let Ok(source_ref) = SourceReference::builder()
+                    .target(target)
+                    .simple_name(simple_name)
+                    .location(SourceLocation::from_tree_sitter_node(location))
+                    .ref_type(ReferenceType::Call)
+                    .build()
+                {
+                    refs.push(source_ref);
+                }
+            }
+        }
+    }
+
+    // Recurse into children
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        extract_calls_recursive(child, source, refs, seen);
+    }
+}
+
+// =============================================================================
+// Combined relationship extraction for entities
+// =============================================================================
+
+/// Extract relationships for function/method entities (CALLS + USES)
+///
+/// This function is designed to be used with the `define_handler!` macro's
+/// `relationships:` parameter.
+pub(crate) fn extract_function_relationships(
+    ctx: &ExtractionContext,
+    node: Node,
+) -> EntityRelationshipData {
+    // Find the function body to search for calls
+    let body_node = find_function_body(node);
+
+    EntityRelationshipData {
+        calls: body_node
+            .map(|b| extract_function_calls(b, ctx.source))
+            .unwrap_or_default(),
+        uses_types: extract_type_references(node, ctx.source),
+        ..Default::default()
+    }
+}
+
+/// Find the body node of a function (statement_block or expression)
+fn find_function_body(node: Node) -> Option<Node> {
+    // Try to find body field directly
+    if let Some(body) = node.child_by_field_name("body") {
+        return Some(body);
+    }
+
+    // For arrow functions, the body might be a direct expression
+    let mut cursor = node.walk();
+    let result = node
+        .children(&mut cursor)
+        .find(|child| child.kind() == "statement_block");
+    result
+}
+
+/// Extract relationships for module entities (IMPORTS + REEXPORTS)
+pub(crate) fn extract_module_relationships(node: Node, source: &str) -> EntityRelationshipData {
+    EntityRelationshipData {
+        imports: extract_imports(node, source),
+        reexports: extract_reexports(node, source),
+        ..Default::default()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn parse_ts(source: &str) -> tree_sitter::Tree {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into())
+            .ok();
+        parser.parse(source, None).unwrap()
+    }
+
+    #[test]
+    fn test_extract_named_imports() {
+        let source = r#"import { foo, bar } from './utils';"#;
+        let tree = parse_ts(source);
+        let imports = extract_imports(tree.root_node(), source);
+
+        assert_eq!(imports.len(), 2);
+        assert!(imports.iter().any(|r| r.simple_name() == "foo"));
+        assert!(imports.iter().any(|r| r.simple_name() == "bar"));
+    }
+
+    #[test]
+    fn test_extract_default_import() {
+        let source = r#"import Utils from './utils';"#;
+        let tree = parse_ts(source);
+        let imports = extract_imports(tree.root_node(), source);
+
+        assert_eq!(imports.len(), 1);
+        assert_eq!(imports[0].simple_name(), "Utils");
+    }
+
+    #[test]
+    fn test_extract_namespace_import() {
+        let source = r#"import * as Utils from './utils';"#;
+        let tree = parse_ts(source);
+        let imports = extract_imports(tree.root_node(), source);
+
+        assert_eq!(imports.len(), 1);
+        assert_eq!(imports[0].simple_name(), "Utils");
+        assert_eq!(imports[0].target(), "utils");
+    }
+
+    #[test]
+    fn test_extract_star_reexport() {
+        let source = r#"export * from './internal';"#;
+        let tree = parse_ts(source);
+        let reexports = extract_reexports(tree.root_node(), source);
+
+        assert_eq!(reexports.len(), 1);
+        assert_eq!(reexports[0].target(), "internal");
+    }
+
+    #[test]
+    fn test_extract_named_reexport() {
+        let source = r#"export { foo, bar } from './internal';"#;
+        let tree = parse_ts(source);
+        let reexports = extract_reexports(tree.root_node(), source);
+
+        assert_eq!(reexports.len(), 2);
+        assert!(reexports.iter().any(|r| r.simple_name() == "foo"));
+        assert!(reexports.iter().any(|r| r.simple_name() == "bar"));
+    }
+
+    #[test]
+    fn test_extract_type_references() {
+        let source = r#"
+            function process(user: User): Result<User> {
+                const data: Data = {};
+                return data;
+            }
+        "#;
+        let tree = parse_ts(source);
+        let refs = extract_type_references(tree.root_node(), source);
+
+        // Should find User (twice but deduplicated), Result, Data
+        assert!(refs.iter().any(|r| r.simple_name() == "User"));
+        assert!(refs.iter().any(|r| r.simple_name() == "Result"));
+        assert!(refs.iter().any(|r| r.simple_name() == "Data"));
+        // Should not include primitives
+        assert!(!refs.iter().any(|r| r.simple_name() == "string"));
+    }
+
+    #[test]
+    fn test_extract_function_calls() {
+        let source = r#"
+            function pipeline() {
+                const a = step1();
+                const b = step2(a);
+                obj.method();
+            }
+        "#;
+        let tree = parse_ts(source);
+        let calls = extract_function_calls(tree.root_node(), source);
+
+        assert!(calls.iter().any(|r| r.simple_name() == "step1"));
+        assert!(calls.iter().any(|r| r.simple_name() == "step2"));
+        assert!(calls.iter().any(|r| r.simple_name() == "method"));
+    }
+}

--- a/crates/languages/src/common/language_extractors.rs
+++ b/crates/languages/src/common/language_extractors.rs
@@ -858,6 +858,31 @@ macro_rules! define_handler {
         }
     };
 
+    // With context-aware name function, metadata, and relationships (uses trait visibility)
+    (
+        $lang:ty,
+        $fn_name:ident,
+        $capture:expr,
+        $entity_type:ident,
+        name_ctx_fn: $name_ctx_fn:expr,
+        metadata: $metadata_fn:expr,
+        relationships: $rel_fn:expr
+    ) => {
+        pub(crate) fn $fn_name(
+            ctx: &$crate::common::entity_building::ExtractionContext,
+        ) -> codesearch_core::error::Result<Vec<codesearch_core::CodeEntity>> {
+            $crate::common::language_extractors::extract_entity_with_name_ctx_fn::<$lang>(
+                ctx,
+                $capture,
+                codesearch_core::entities::EntityType::$entity_type,
+                $name_ctx_fn,
+                None,
+                $metadata_fn,
+                $rel_fn,
+            )
+        }
+    };
+
     // =========================================================================
     // Module entity variant (file-level entities with path-based qualified names)
     // =========================================================================
@@ -975,6 +1000,12 @@ macro_rules! define_ts_family_handler {
     ($ts_fn:ident, $tsx_fn:ident, $capture:expr, $entity_type:ident, name_ctx_fn: $name_ctx_fn:expr, relationships: $rel_fn:expr) => {
         $crate::define_handler!($crate::common::js_ts_shared::TypeScript, $ts_fn, $capture, $entity_type, name_ctx_fn: $name_ctx_fn, relationships: $rel_fn);
         $crate::define_handler!($crate::common::js_ts_shared::Tsx, $tsx_fn, $capture, $entity_type, name_ctx_fn: $name_ctx_fn, relationships: $rel_fn);
+    };
+
+    // With context-aware name function, metadata, and relationships
+    ($ts_fn:ident, $tsx_fn:ident, $capture:expr, $entity_type:ident, name_ctx_fn: $name_ctx_fn:expr, metadata: $metadata_fn:expr, relationships: $rel_fn:expr) => {
+        $crate::define_handler!($crate::common::js_ts_shared::TypeScript, $ts_fn, $capture, $entity_type, name_ctx_fn: $name_ctx_fn, metadata: $metadata_fn, relationships: $rel_fn);
+        $crate::define_handler!($crate::common::js_ts_shared::Tsx, $tsx_fn, $capture, $entity_type, name_ctx_fn: $name_ctx_fn, metadata: $metadata_fn, relationships: $rel_fn);
     };
 
     // Module entity variant

--- a/crates/languages/src/common/module_utils.rs
+++ b/crates/languages/src/common/module_utils.rs
@@ -9,16 +9,49 @@ use std::path::Path;
 ///
 /// The module name is the file name without extension.
 /// For TypeScript declaration files, also strips the `.d` suffix.
+/// For index files (barrel files in JS/TS) in subdirectories, returns the parent directory name.
 /// e.g., "/src/utils/helpers.js" -> "helpers"
 /// e.g., "/src/types/ambient.d.ts" -> "ambient"
+/// e.g., "/src/models/index.ts" -> "models"
+/// e.g., "/src/index.ts" -> "index" (no parent dir name to use)
 pub fn derive_module_name(file_path: &Path) -> String {
-    let name = file_path
+    let stem = file_path
         .file_stem()
         .and_then(|s| s.to_str())
         .unwrap_or("module");
 
     // Strip .d suffix for TypeScript declaration files
-    name.strip_suffix(".d").unwrap_or(name).to_string()
+    let name = stem.strip_suffix(".d").unwrap_or(stem);
+
+    // For index files with JS/TS extensions, use the parent directory name
+    // This is the barrel file convention in JavaScript/TypeScript
+    // Only apply when there's a meaningful parent directory name
+    if name == "index" && is_js_ts_file(file_path) {
+        if let Some(parent_name) = file_path
+            .parent()
+            .and_then(|p| p.file_name())
+            .and_then(|n| n.to_str())
+        {
+            // Only use parent name if it's non-empty
+            if !parent_name.is_empty() {
+                return parent_name.to_string();
+            }
+        }
+    }
+
+    name.to_string()
+}
+
+/// Check if a file is a JavaScript or TypeScript file based on extension
+fn is_js_ts_file(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| {
+            matches!(
+                ext,
+                "js" | "jsx" | "ts" | "tsx" | "mjs" | "cjs" | "mts" | "cts"
+            )
+        })
 }
 
 /// Derive qualified name for the module from file path
@@ -54,21 +87,47 @@ pub fn derive_qualified_name(
 /// Derive qualified name from a path relative to some root
 ///
 /// This is the core logic shared between qualified_name and path_entity_identifier.
+/// Treats `index.*` JS/TS files as representing their parent directory (barrel file convention),
+/// but only when there's a parent directory (not for root-level index files).
 fn build_qualified_name_from_relative(relative: &Path, separator: &str) -> String {
     let mut parts: Vec<&str> = Vec::new();
+
+    // Check if this is a JS/TS index file (barrel file convention)
+    // Only treat as barrel if it's in a subdirectory (has parent components)
+    let is_index = is_js_ts_file(relative)
+        && relative
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .is_some_and(|name| name == "index" || name == "index.d");
+
+    // Count components to check if there are parent directories
+    let component_count = relative
+        .components()
+        .filter(|c| matches!(c, std::path::Component::Normal(_)))
+        .count();
+
+    // Only treat as barrel index if there's at least one directory above it
+    let is_barrel_index = is_index && component_count > 1;
 
     for component in relative.components() {
         if let std::path::Component::Normal(s) = component {
             if let Some(s) = s.to_str() {
                 // Skip file extension for the last component
-                let name = if relative.extension().is_some()
-                    && relative.file_name() == Some(std::ffi::OsStr::new(s))
-                {
-                    s.rsplit('.').next_back().unwrap_or(s)
-                } else {
-                    s
-                };
-                parts.push(name);
+                let is_last = relative.file_name() == Some(std::ffi::OsStr::new(s));
+
+                if is_last {
+                    // For barrel index files, skip adding "index" - directory name is sufficient
+                    if is_barrel_index {
+                        continue;
+                    }
+                    // Strip extension from file name
+                    if relative.extension().is_some() {
+                        let name = s.rsplit('.').next_back().unwrap_or(s);
+                        parts.push(name);
+                        continue;
+                    }
+                }
+                parts.push(s);
             }
         }
     }
@@ -192,9 +251,28 @@ mod tests {
     fn test_derive_path_entity_identifier_nested() {
         let path = PathBuf::from("/project/packages/core/src/index.ts");
         let repo_root = PathBuf::from("/project");
+        // index.ts files are treated as barrel files, so "index" is omitted
         assert_eq!(
             derive_path_entity_identifier(&path, &repo_root, "."),
-            "packages.core.src.index"
+            "packages.core.src"
+        );
+    }
+
+    #[test]
+    fn test_derive_module_name_index_file() {
+        // index.ts should use parent directory name
+        let path = PathBuf::from("/project/models/index.ts");
+        assert_eq!(derive_module_name(&path), "models");
+    }
+
+    #[test]
+    fn test_derive_qualified_name_index_file() {
+        // index.ts should not include "index" in qualified name
+        let path = PathBuf::from("/project/models/index.ts");
+        let repo_root = PathBuf::from("/project");
+        assert_eq!(
+            derive_qualified_name(&path, None, &repo_root, "."),
+            "models"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Add `relationships.rs` module with extraction functions for IMPORTS, REEXPORTS, USES (type references), and CALLS (function/method calls)
- Update module and function handlers to populate `EntityRelationshipData` fields
- Add barrel file convention: `index.ts` files in subdirectories use parent directory name for module naming

Fixes #185

## Test plan
- [x] All 7 previously failing TypeScript spec validation tests now pass:
  - `test_function_calls` - CALLS
  - `test_async_functions` - CALLS
  - `test_imports_exports` - IMPORTS
  - `test_default_exports` - IMPORTS
  - `test_barrel_exports` - REEXPORTS
  - `test_reexports` - REEXPORTS
  - `test_type_usage` - USES
- [x] All 46 TypeScript e2e tests pass
- [x] All workspace unit tests pass
- [x] Clippy and fmt pass

🤖 Generated with [Claude Code](https://claude.ai/code)