### PR TITLE
Add custom predicate evaluation for method/function disambiguation

### DIFF
--- a/crates/languages/specs/rust.yaml
+++ b/crates/languages/specs/rust.yaml
@@ -819,6 +819,7 @@ extraction_hints:
           parameters: (parameters) @params
           return_type: (_)? @return_type
           body: (block) @body) @function
+        (#not-has-ancestor? @function impl_item)
 
     # --- Impl block queries ---
 

--- a/crates/languages/src/queries.rs
+++ b/crates/languages/src/queries.rs
@@ -1,4 +1,4 @@
-//! Query definitions for entity extraction (V2 Architecture)
+//! Query definitions for entity extraction
 //!
 //! This module defines tree-sitter queries as Rust constants, providing
 //! type-safe query definitions with associated metadata.


### PR DESCRIPTION
## Summary
- Implement structural AST checks in `should_skip_match()` to evaluate tree-sitter predicates that aren't automatically evaluated
- Add `#not-has-child? @params self_parameter` evaluation to skip associated functions that have self parameter
- Add `#not-has-ancestor? @function impl_item` evaluation to skip functions inside impl blocks
- Update `FUNCTION_FREE` query in rust.yaml with the predicate

## Test plan
- [x] `test_builder_pattern` now passes
- [ ] Other tests have separate issues (qualified name scoping, `&self` vs `self` parsing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)