### PR TITLE
Fix foreign type detection in trait impl qualified names

### DIFF
--- a/crates/languages/specs/rust.yaml
+++ b/crates/languages/specs/rust.yaml
@@ -857,6 +857,7 @@ extraction_hints:
           ]
           type: [
             (type_identifier) @impl_type_name
+            (primitive_type) @impl_type_name
             (generic_type
               type: (type_identifier) @impl_type_name
               type_arguments: (type_arguments) @impl_type_args)
@@ -939,6 +940,7 @@ extraction_hints:
           ]
           type: [
             (type_identifier) @impl_type_name
+            (primitive_type) @impl_type_name
             (generic_type type: (type_identifier) @impl_type_name)
             (scoped_type_identifier name: (type_identifier) @impl_type_name)
           ]


### PR DESCRIPTION
## Summary
- Add std type check to prevent prefixing well-known types like `String` and `str` with the local crate name in trait impl qualified names
- Add `primitive_type` support to `IMPL_TRAIT` and `METHOD_IN_TRAIT_IMPL` queries to capture primitive types like `str`

Fixes #207

## Test plan
- [x] Run `extension_traits` test - entity qualified names now correct (`<String as test_crate::StringExt>`, `<str as test_crate::StringExt>`)
- [x] Run full Rust test suite - no regressions (35 passed, 15 failed - same as baseline)

🤖 Generated with [Claude Code](https://claude.ai/code)