### PR TITLE
Fix extern block parent scope for contained items

### DIFF
--- a/crates/languages/build.rs
+++ b/crates/languages/build.rs
@@ -69,6 +69,8 @@ struct HandlerDef {
     #[serde(default)]
     qualified_name_template: Option<String>,
     #[serde(default)]
+    parent_scope_template: Option<String>,
+    #[serde(default)]
     metadata: Option<String>,
     #[serde(default)]
     relationships: Option<String>,
@@ -257,6 +259,16 @@ fn generate_handler_configs(
             writeln!(output, "        visibility_override: {vis_str},")?;
         } else {
             writeln!(output, "        visibility_override: None,")?;
+        }
+
+        if let Some(ref template) = handler.parent_scope_template {
+            writeln!(
+                output,
+                "        parent_scope_template: Some(r#\"{}\"#),",
+                template
+            )?;
+        } else {
+            writeln!(output, "        parent_scope_template: None,")?;
         }
 
         writeln!(output, "    }};")?;

--- a/crates/languages/specs/rust.yaml
+++ b/crates/languages/specs/rust.yaml
@@ -1161,6 +1161,8 @@ extraction_hints:
       capture: "function"
       query: |
         (foreign_mod_item
+          (extern_modifier
+            (string_literal)? @abi)
           body: (declaration_list
             (function_signature_item
               name: (identifier) @name
@@ -1172,6 +1174,8 @@ extraction_hints:
       capture: "static"
       query: |
         (foreign_mod_item
+          (extern_modifier
+            (string_literal)? @abi)
           body: (declaration_list
             (static_item
               name: (identifier) @name
@@ -1491,6 +1495,7 @@ extraction_hints:
       capture: "function"
       name_strategy: capture
       qualified_name_template: "{scope}::{name}"
+      parent_scope_template: '{scope}::extern {abi}'
       # visibility_override removed - use actual visibility from source
 
     ExternStatic:
@@ -1499,6 +1504,7 @@ extraction_hints:
       capture: "static"
       name_strategy: capture
       qualified_name_template: "{scope}::{name}"
+      parent_scope_template: '{scope}::extern {abi}'
       # visibility_override removed - use actual visibility from source
 
     # --- Macro handlers ---

--- a/crates/languages/src/spec_driven/extractors.rs
+++ b/crates/languages/src/spec_driven/extractors.rs
@@ -57,6 +57,7 @@ inventory::submit! {
         module_path_fn: Some(rust_module_path::derive_module_path),
         path_config: &CRATE_BASED_PATH_CONFIG,
         edge_case_handlers: Some(RUST_EDGE_CASE_HANDLERS),
+        custom_scope_extractor: None,
     }
 }
 
@@ -68,6 +69,7 @@ inventory::submit! {
         module_path_fn: Some(js_module_path::derive_module_path),
         path_config: &MODULE_BASED_PATH_CONFIG,
         edge_case_handlers: None,
+        custom_scope_extractor: None,
     }
 }
 
@@ -79,6 +81,7 @@ inventory::submit! {
         module_path_fn: Some(js_module_path::derive_module_path),
         path_config: &MODULE_BASED_PATH_CONFIG,
         edge_case_handlers: None,
+        custom_scope_extractor: None,
     }
 }
 
@@ -90,6 +93,7 @@ inventory::submit! {
         module_path_fn: Some(js_module_path::derive_module_path),
         path_config: &MODULE_BASED_PATH_CONFIG,
         edge_case_handlers: None,
+        custom_scope_extractor: None,
     }
 }
 

--- a/crates/languages/src/spec_driven/mod.rs
+++ b/crates/languages/src/spec_driven/mod.rs
@@ -75,6 +75,14 @@ pub struct HandlerConfig {
 
     /// Override visibility (e.g., Public for trait impl members)
     pub visibility_override: Option<Visibility>,
+
+    /// Optional template for overriding parent_scope derivation.
+    /// Uses placeholders like {scope}, {abi}, etc.
+    /// When set, this template determines the containment relationship parent,
+    /// independent of the qualified_name_template.
+    /// Useful for extern items where the parent should be the extern block but
+    /// the qualified name shouldn't include the extern block path.
+    pub parent_scope_template: Option<&'static str>,
 }
 
 /// Strategy for deriving entity names from query captures


### PR DESCRIPTION
## Summary
- Add `parent_scope_template` field to handler configs, allowing containment relationships to differ from qualified name structure
- Extern functions and statics now correctly have the extern block as their parent while maintaining their module-level qualified names
- Add extension point for custom scope extraction in language configurations

Fixes #208

## Test plan
- [x] Run `test_extern_blocks` spec validation test
- [x] Run all unit tests in codesearch-languages crate
- [x] Verify no regressions in other Rust spec validation tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)