### PR TITLE
Fix method chain call resolution for builder patterns

### DIFF
--- a/crates/core/src/resolution.rs
+++ b/crates/core/src/resolution.rs
@@ -108,6 +108,9 @@ pub mod definitions {
     pub const MODULE_TYPES: &[EntityType] = &[EntityType::Module];
 
     /// CALLS relationship: Function/Method calls other Function/Method
+    ///
+    /// Uses SimpleName as a fallback for method chain resolution where type
+    /// information is not available (e.g., `.name()` in `Builder::new().name()`).
     pub const CALLS: RelationshipDef = RelationshipDef::new(
         "calls",
         CALLABLE_TYPES,
@@ -117,6 +120,7 @@ pub mod definitions {
             LookupStrategy::QualifiedName,
             LookupStrategy::CallAliases,
             LookupStrategy::UniqueSimpleName,
+            LookupStrategy::SimpleName,
         ],
     );
 


### PR DESCRIPTION
## Summary
- Capture method calls in chains (e.g., `.name()` in `Builder::new().name()`) as unresolved calls with just the method name
- Add SimpleName as a fallback lookup strategy for CALLS relationships to enable post-processing resolution

Fixes #209

## Test plan
- [x] `test_builder_pattern` passes
- [x] `test_trait_vs_inherent_method` passes
- [x] `test_scattered_impl_blocks` still fails (expected - different issue about qualified names)
- [x] All unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)