### PR TITLE
Add USES relationship extraction for type aliases

### DIFF
--- a/crates/languages/specs/rust.yaml
+++ b/crates/languages/specs/rust.yaml
@@ -1438,6 +1438,7 @@ extraction_hints:
       capture: "type_alias"
       name_strategy: capture
       qualified_name_template: "{scope}::{name}"
+      relationships: extract_type_relationships
 
     AssociatedTypeInTraitImpl:
       entity_rule: E-TYPE-ALIAS-ASSOC
@@ -1569,7 +1570,10 @@ fixtures:
     tests: [E-EXTERN-BLOCK, E-EXTERN-FN, E-EXTERN-STATIC, R-CONTAINS-EXTERN-ITEM]
 
   type_aliases:
-    tests: [E-TYPE-ALIAS, M-TYPE-ALIAS-TARGET]
+    tests: [E-TYPE-ALIAS, M-TYPE-ALIAS-TARGET, R-USES-TYPE]
+
+  type_alias_chains:
+    tests: [E-TYPE-ALIAS, R-USES-TYPE]
 
   async_functions:
     tests: [M-FN-ASYNC]


### PR DESCRIPTION
## Summary
- Adds `relationships: extract_type_relationships` to TypeAlias handler in rust.yaml
- Updates type_aliases fixture to test R-USES-TYPE relationship
- Adds type_alias_chains fixture entry

Fixes #210

## Test plan
- [x] `test_type_aliases` passes - USES relationships now extracted from type aliases to target types

🤖 Generated with [Claude Code](https://claude.com/claude-code)