### PR TITLE
Add git worktree workflow with Claude Code safety hooks

### DIFF
--- a/.claude/hooks/guard-bash-on-main.sh
+++ b/.claude/hooks/guard-bash-on-main.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+# Guard: prevent modifying Bash commands when CWD is on main with worktrees.
+# Three layers: worktree escape -> redirect check -> command whitelist.
+set -euo pipefail
+
+INPUT=$(cat)
+COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty')
+[[ -z "$COMMAND" ]] && exit 0
+
+REPO_ROOT="${CLAUDE_PROJECT_DIR:-}"
+[[ -z "$REPO_ROOT" ]] && exit 0
+
+# Determine CWD: prefer JSON field, fall back to $PWD
+CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // empty')
+CWD="${CWD:-$PWD}"
+
+# Only guard when CWD is on main (not inside a worktree)
+[[ "$CWD" != "$REPO_ROOT" ]] && exit 0
+
+# Only guard when worktrees exist (more than just main)
+if [[ $(git -C "$REPO_ROOT" worktree list 2>/dev/null | wc -l) -le 1 ]]; then
+  exit 0
+fi
+
+deny() {
+  jq -n --arg r "$1" '{
+    "hookSpecificOutput": {
+      "hookEventName": "PreToolUse",
+      "permissionDecision": "deny",
+      "permissionDecisionReason": $r
+    }
+  }'
+  exit 0
+}
+
+# === Layer 1: Worktree escape hatch ===
+# Allow if the first action is cd-ing into .worktrees/
+first_segment=$(printf '%s' "$COMMAND" | head -1 | sed -E 's/[[:space:]]*(&&|\|\||[;|]).*//')
+cd_target=$(printf '%s' "$first_segment" | sed -n 's/^[[:space:]]*cd[[:space:]]\{1,\}//p' | sed 's/^"//;s/"$//' | sed 's/[[:space:]]*$//')
+if [[ -n "$cd_target" ]]; then
+  if [[ "$cd_target" == .worktrees/* || "$cd_target" == "$REPO_ROOT"/.worktrees/* ]]; then
+    exit 0
+  fi
+fi
+
+# Allow git -C .worktrees/...
+git_c_target=$(printf '%s' "$COMMAND" | sed -n 's/^[[:space:]]*git[[:space:]]\{1,\}-C[[:space:]]\{1,\}\([^[:space:]]*\).*/\1/p' | sed 's/^"//;s/"$//')
+if [[ -n "$git_c_target" ]]; then
+  if [[ "$git_c_target" == .worktrees/* || "$git_c_target" == "$REPO_ROOT"/.worktrees/* ]]; then
+    exit 0
+  fi
+fi
+
+# === Layer 2: Output redirection check ===
+# Remove heredocs (<<WORD, <<-WORD) and herestrings (<<<) to avoid false positives
+sanitized="$COMMAND"
+sanitized=$(printf '%s' "$sanitized" | sed -E "s/<<<[^;|&)]*//g; s/<<-?[[:space:]]*['\"]?[A-Za-z_]+['\"]?//g")
+# Remove fd-to-fd redirects (2>&1, >&2, etc.)
+sanitized=$(printf '%s' "$sanitized" | sed -E 's/[0-9]*>&[0-9-]+//g')
+# Find remaining file redirects: [n]> or [n]>> or &> or &>> followed by a path
+redirect_targets=$(printf '%s' "$sanitized" | grep -oE '[0-9&]*>{1,2}[[:space:]]*[^[:space:];&|)>]+' || true)
+
+if [[ -n "$redirect_targets" ]]; then
+  while IFS= read -r match; do
+    target=$(printf '%s' "$match" | sed -E 's/^[0-9&]*>{1,2}[[:space:]]*//')
+    [[ -z "$target" ]] && continue
+    case "$target" in
+      /dev/null|/dev/stderr|/dev/stdout) continue ;;
+      /tmp/*|/tmp) continue ;;
+      .worktrees/*) continue ;;
+    esac
+    if [[ "$target" == "$REPO_ROOT"/.worktrees/* ]]; then
+      continue
+    fi
+    deny "Bash BLOCKED on main: redirect to '$target'. Run in a worktree."
+  done <<< "$redirect_targets"
+fi
+
+# === Layer 3: Command whitelist ===
+declare -A SAFE_CMDS=(
+  # Navigation
+  [cd]=1 [pwd]=1 [pushd]=1 [popd]=1
+  # File reading
+  [ls]=1 [cat]=1 [head]=1 [tail]=1 [less]=1 [more]=1 [bat]=1
+  [file]=1 [stat]=1 [readlink]=1 [realpath]=1 [wc]=1 [du]=1 [df]=1
+  # Text processing (read-only)
+  [grep]=1 [egrep]=1 [fgrep]=1 [rg]=1 [ag]=1 [ack]=1
+  [sort]=1 [uniq]=1 [cut]=1 [tr]=1 [column]=1 [paste]=1 [join]=1 [comm]=1
+  [diff]=1 [cmp]=1 [jq]=1 [yq]=1 [xq]=1 [awk]=1 [gawk]=1 [sed]=1
+  # Searching
+  [find]=1 [fd]=1 [locate]=1 [which]=1 [type]=1 [whereis]=1 [command]=1
+  # Output (safe without redirect; caught by layer 2)
+  [echo]=1 [printf]=1 [true]=1 [false]=1 [test]=1 ['[']=1
+  # System info
+  [uname]=1 [whoami]=1 [id]=1 [hostname]=1 [date]=1 [cal]=1 [time]=1
+  [uptime]=1 [free]=1 [env]=1 [printenv]=1 [nproc]=1 [lscpu]=1 [arch]=1
+  # Process info
+  [ps]=1 [pgrep]=1 [pidof]=1 [lsof]=1 [ss]=1 [netstat]=1
+  # Checksums
+  [md5sum]=1 [sha256sum]=1 [sha1sum]=1 [shasum]=1 [b2sum]=1
+  # Git & GitHub (git subcommands checked separately)
+  [git]=1 [gh]=1
+  # Infrastructure
+  [docker]=1 [docker-compose]=1 [podman]=1 [kubectl]=1 [k9s]=1 [kind]=1 [helm]=1
+)
+
+declare -A SAFE_GIT_SUBCMDS=(
+  [status]=1 [log]=1 [diff]=1 [show]=1 [blame]=1 [shortlog]=1 [reflog]=1
+  [describe]=1 [branch]=1 [tag]=1 [remote]=1 [fetch]=1 [push]=1 [worktree]=1
+  [stash]=1 [rev-parse]=1 [ls-files]=1 [cat-file]=1 [ls-tree]=1
+  [for-each-ref]=1 [config]=1 [version]=1
+)
+
+# Split command on &&, ||, ;, | and newlines; check each segment
+while IFS= read -r segment || [[ -n "$segment" ]]; do
+  segment=$(printf '%s' "$segment" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+  [[ -z "$segment" ]] && continue
+
+  # Strip leading variable assignments (FOO=bar, FOO="val", FOO='val')
+  local_segment="$segment"
+  while true; do
+    prev="$local_segment"
+    local_segment=$(printf '%s' "$local_segment" | sed -E "s/^[A-Za-z_][A-Za-z_0-9]*=(\"[^\"]*\"|'[^']*'|[^[:space:]]*)[[:space:]]+//")
+    [[ "$local_segment" == "$prev" ]] && break
+  done
+
+  # Bare assignment with no command (e.g., FOO=bar) -- allow
+  if printf '%s' "$local_segment" | grep -qE '^[A-Za-z_][A-Za-z_0-9]*='; then
+    stripped=$(printf '%s' "$local_segment" | sed -E "s/^[A-Za-z_][A-Za-z_0-9]*=(\"[^\"]*\"|'[^']*'|[^[:space:]]*)$//")
+    if [[ -z "$stripped" ]]; then
+      continue
+    fi
+  fi
+  [[ -z "$local_segment" ]] && continue
+
+  # Extract first word (the command)
+  cmd_word=$(printf '%s' "$local_segment" | awk '{print $1}')
+  cmd_base=$(basename "$cmd_word" 2>/dev/null || printf '%s' "$cmd_word")
+
+  # Check whitelist
+  if [[ -z "${SAFE_CMDS[$cmd_base]+x}" ]]; then
+    deny "Bash BLOCKED on main: '$cmd_base' is not whitelisted. Run in a worktree."
+  fi
+
+  # Special: sed -i / --in-place
+  if [[ "$cmd_base" == "sed" ]]; then
+    sed_args=$(printf '%s' "$local_segment" | sed 's/^[[:space:]]*sed[[:space:]]*//')
+    if printf '%s' "$sed_args" | grep -qE '(^|[[:space:]])-[a-zA-Z]*i([[:space:]]|\.|$)|(^|[[:space:]])--in-place([[:space:]]|$)'; then
+      deny "Bash BLOCKED on main: 'sed -i/--in-place' modifies files. Run in a worktree."
+    fi
+  fi
+
+  # Special: git subcommand check
+  if [[ "$cmd_base" == "git" ]]; then
+    git_subcmd=""
+    skip_next=false
+    while IFS= read -r word || [[ -n "$word" ]]; do
+      if $skip_next; then
+        skip_next=false
+        continue
+      fi
+      case "$word" in
+        -C|--git-dir|--work-tree|-c) skip_next=true; continue ;;
+        -*) continue ;;
+        *) git_subcmd="$word"; break ;;
+      esac
+    done < <(printf '%s' "$local_segment" | awk '{for(i=2;i<=NF;i++) print $i}')
+
+    [[ -z "$git_subcmd" ]] && continue
+
+    if [[ -z "${SAFE_GIT_SUBCMDS[$git_subcmd]+x}" ]]; then
+      deny "Bash BLOCKED on main: 'git $git_subcmd' is not whitelisted. Run in a worktree."
+    fi
+
+    # Special: only stash list/show are safe
+    if [[ "$git_subcmd" == "stash" ]]; then
+      stash_action=$(printf '%s' "$local_segment" | sed -n 's/.*stash[[:space:]]\{1,\}\([a-z]*\).*/\1/p')
+      case "${stash_action:-push}" in
+        list|show) ;;
+        *) deny "Bash BLOCKED on main: 'git stash ${stash_action:-push}' is not whitelisted. Run in a worktree." ;;
+      esac
+    fi
+  fi
+done < <(printf '%s' "$COMMAND" | sed -E 's/[[:space:]]*(&&|\|\||[;|])[[:space:]]*/\n/g')
+
+# All checks passed
+exit 0

--- a/.claude/hooks/guard-worktree-edit.sh
+++ b/.claude/hooks/guard-worktree-edit.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Guard: prevent file edits outside the active worktree.
+# Main repo source files are read-only; edits must go through .worktrees/.
+set -euo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [[ -z "$FILE_PATH" ]]; then
+  exit 0
+fi
+
+REPO_ROOT="${CLAUDE_PROJECT_DIR:-}"
+if [[ -z "$REPO_ROOT" ]]; then
+  exit 0
+fi
+
+# Allow: files outside the repo entirely (e.g. ~/.claude/memory)
+if [[ "$FILE_PATH" != "$REPO_ROOT"/* ]]; then
+  exit 0
+fi
+
+# Allow: files inside a worktree
+if [[ "$FILE_PATH" == "$REPO_ROOT/.worktrees/"* ]]; then
+  exit 0
+fi
+
+# Allow: Claude Code config
+if [[ "$FILE_PATH" == "$REPO_ROOT/.claude/"* ]]; then
+  exit 0
+fi
+
+# Deny: everything else under repo root (main is read-only)
+jq -n --arg path "$FILE_PATH" '{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": ("File edit BLOCKED: " + $path + " is on main. Edits must target a worktree under .worktrees/. Use `git worktree list` to find the right path.")
+  }
+}'

--- a/.claude/hooks/guard-worktree-escape.sh
+++ b/.claude/hooks/guard-worktree-escape.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Guard: prevent leaving a worktree without permission.
+# When CWD is inside a worktree and a command would cd to the repo root,
+# check git/GitHub state to decide whether to allow or block.
+#
+# ALLOW if the branch's PR is merged (cleanup is expected).
+# DENY  if there are uncommitted changes, unpushed commits, an open PR,
+#       or no PR exists yet.
+set -euo pipefail
+
+INPUT=$(cat)
+COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty')
+[[ -z "$COMMAND" ]] && exit 0
+
+REPO_ROOT="${CLAUDE_PROJECT_DIR:-}"
+[[ -z "$REPO_ROOT" ]] && exit 0
+
+# Determine CWD
+CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // empty')
+CWD="${CWD:-$PWD}"
+
+# Only guard when CWD is inside a worktree
+[[ "$CWD" != "$REPO_ROOT"/.worktrees/* ]] && exit 0
+
+# Extract worktree root (e.g., /repo/.worktrees/329--foo/client -> /repo/.worktrees/329--foo)
+WORKTREE_ROOT=$(printf '%s' "$CWD" | sed -E "s|^($REPO_ROOT/\.worktrees/[^/]+).*|\1|")
+
+deny() {
+  jq -n --arg r "$1" '{
+    "hookSpecificOutput": {
+      "hookEventName": "PreToolUse",
+      "permissionDecision": "deny",
+      "permissionDecisionReason": $r
+    }
+  }'
+  exit 0
+}
+
+# === Detect cd-to-repo-root ===
+has_escape=false
+has_worktree_reentry=false
+
+while IFS= read -r segment || [[ -n "$segment" ]]; do
+  segment=$(printf '%s' "$segment" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+  [[ -z "$segment" ]] && continue
+
+  printf '%s' "$segment" | grep -qE '^\s*cd\s' || continue
+
+  cd_target=$(printf '%s' "$segment" | sed -n 's/^[[:space:]]*cd[[:space:]]\{1,\}//p' | sed 's/^"//;s/"$//' | sed 's/[[:space:]]*$//')
+  [[ -z "$cd_target" ]] && continue
+
+  resolved=$(cd "$CWD" && realpath -m "$cd_target" 2>/dev/null || printf '%s' "$cd_target")
+
+  if [[ "$resolved" == "$REPO_ROOT" ]]; then
+    has_escape=true
+  elif [[ "$resolved" == "$REPO_ROOT"/.worktrees/* ]]; then
+    has_worktree_reentry=true
+  fi
+done < <(printf '%s' "$COMMAND" | sed -E 's/[[:space:]]*(&&|\|\||[;|])[[:space:]]*/\n/g')
+
+# No escape detected
+$has_escape || exit 0
+
+# If command also re-enters a worktree (switching worktrees), allow
+$has_worktree_reentry && exit 0
+
+# === State checks (cheapest first) ===
+BRANCH=$(git -C "$WORKTREE_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+[[ -z "$BRANCH" || "$BRANCH" == "HEAD" ]] && exit 0
+
+# 1. Uncommitted changes (cheapest)
+if [[ -n $(git -C "$WORKTREE_ROOT" status --porcelain 2>/dev/null | head -1) ]]; then
+  deny "Leaving worktree BLOCKED: uncommitted changes on '$BRANCH'. Commit or stash before leaving."
+fi
+
+# 2. Unpushed commits (cheap, but need upstream)
+HAS_UPSTREAM=$(git -C "$WORKTREE_ROOT" rev-parse --abbrev-ref '@{u}' 2>/dev/null || echo "")
+if [[ -z "$HAS_UPSTREAM" ]]; then
+  deny "Leaving worktree BLOCKED: branch '$BRANCH' has never been pushed."
+fi
+if [[ -n $(git -C "$WORKTREE_ROOT" log '@{u}..HEAD' --oneline 2>/dev/null | head -1) ]]; then
+  deny "Leaving worktree BLOCKED: unpushed commits on '$BRANCH'. Push before leaving."
+fi
+
+# 3. PR state (expensive -- only reached when tree is clean and pushed)
+REMOTE_URL=$(git -C "$WORKTREE_ROOT" remote get-url origin 2>/dev/null || echo "")
+REPO_SLUG=$(printf '%s' "$REMOTE_URL" | sed -E 's|.*github\.com[:/]||;s|\.git$||')
+PR_STATE=$(gh pr view "$BRANCH" --repo "$REPO_SLUG" --json state -q .state 2>/dev/null || echo "NONE")
+
+if [[ "$PR_STATE" == "MERGED" ]]; then
+  exit 0
+fi
+
+if [[ "$PR_STATE" == "OPEN" ]]; then
+  deny "Leaving worktree BLOCKED: PR for '$BRANCH' is still open."
+fi
+
+deny "Leaving worktree BLOCKED: no merged PR found for '$BRANCH'. Stay in the worktree or get user approval."

--- a/.claude/hooks/warn-worktree-drift.sh
+++ b/.claude/hooks/warn-worktree-drift.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Warn: detect when CWD has drifted out of .worktrees/ after a Bash command.
+set -euo pipefail
+
+INPUT=$(cat)
+
+REPO_ROOT="${CLAUDE_PROJECT_DIR:-}"
+if [[ -z "$REPO_ROOT" ]]; then
+  exit 0
+fi
+
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+if [[ -z "$CWD" ]]; then
+  exit 0
+fi
+
+# Only warn if CWD is the repo root (not in a worktree)
+if [[ "$CWD" != "$REPO_ROOT" ]]; then
+  exit 0
+fi
+
+# Check if any worktrees exist (besides main)
+WORKTREE_COUNT=$(git -C "$REPO_ROOT" worktree list --porcelain 2>/dev/null | grep -c '^worktree ' || true)
+if [[ "$WORKTREE_COUNT" -le 1 ]]; then
+  exit 0
+fi
+
+# CWD is repo root and worktrees exist -- warn
+jq -n '{
+  "hookSpecificOutput": {
+    "hookEventName": "PostToolUse",
+    "additionalContext": "WARNING: CWD is on main but worktrees exist. If you are working in a worktree, cd back into it now."
+  }
+}'
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,48 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/guard-worktree-edit.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/guard-bash-on-main.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/guard-worktree-escape.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/warn-worktree-drift.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ package-lock.json
 **/__pycache__
 **/.deepeval/
 logs/
+
+# Git worktrees
+.worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,11 +10,9 @@ Codesearch is a Rust-based semantic code indexing system that provides intellige
 
 ```
 codesearch/
-├── .git/                # Shared git directory (separate from worktrees)
-├── main/                # Worktree for main branch
-├── <branch-name>/       # Additional worktrees for feature branches
-│
-# Within each worktree:
+├── .git/                # Normal git directory (main checked out at repo root)
+├── .worktrees/          # Feature branch worktrees only
+│   └── <branch-name>/
 ├── crates/              # Rust workspace crates
 │   ├── core/            # Foundation types, config, error handling
 │   ├── languages/       # AST parsing with spec-driven YAML config
@@ -39,13 +37,41 @@ codesearch/
 └── CLAUDE.md            # This file
 ```
 
-## WORKTREE WORKFLOW
+## Git Worktree Workflow
 
-This project uses git worktrees with a separate git directory for parallel development. Each issue or feature gets its own worktree.
+All feature work MUST use git worktrees for isolation. Never commit feature work directly to main.
 
-**Important:** The parent directory containing `.git/` is NOT a worktree. All worktrees (`main/`, `feature--xyz/`, etc.) are subdirectories. All worktree management commands must be run from this parent directory.
+- **Main is read-only:** Four hooks enforce this:
+  - `guard-worktree-edit.sh` (PreToolUse, Edit|Write) - blocks file writes outside `.worktrees/` and `.claude/`
+  - `guard-bash-on-main.sh` (PreToolUse, Bash) - blocks non-whitelisted shell commands when CWD is on main with worktrees present
+  - `guard-worktree-escape.sh` (PreToolUse, Bash) - blocks leaving a worktree (`cd` to repo root) unless the branch's PR is merged
+  - `warn-worktree-drift.sh` (PostToolUse, Bash) - warns if CWD drifts to repo root while worktrees exist
+- `cd` into the worktree root before starting work so it becomes CWD
+- Hook changes are git-tracked and must be committed on a branch, not main
 
-**Important:** Never use `git checkout <branch>` inside a worktree. Worktrees are permanently tied to their specific branch.
+### Creating a worktree
+- ALWAYS run `git worktree list` before creating a new worktree -- one may already exist
+- NEVER create a new worktree when work is in progress on one
+
+```bash
+git worktree add .worktrees/<branch-name>
+cd .worktrees/<branch-name>
+```
+- Directory name MUST match branch name (do NOT use `-b` with a different name)
+- This creates both the worktree directory and the branch in one step
+
+### Working in a worktree
+- NEVER run `git checkout <branch>` inside a worktree -- worktrees are locked to their branch
+- To run commands that the bash guard blocks on main (cargo test, npm install, etc.), `cd` into a worktree first
+
+### Cleanup after merge
+The escape guard will allow `cd` to repo root only once the PR is merged:
+```bash
+cd <repo-root>
+git worktree remove .worktrees/<branch-name>
+git branch -D <branch-name>
+```
+- NEVER remove a worktree while it is the shell CWD
 
 ## Rust Development Practices
 


### PR DESCRIPTION
## Summary
- Migrate repo from `core.worktree` layout (source in `main/` subdir) to standard layout (source at repo root)
- Add four Claude Code hook scripts enforcing read-only main, bash command whitelisting, worktree escape prevention, and CWD drift warnings
- Update CLAUDE.md and .gitignore for the new worktree workflow

## Test plan
- [ ] Verify `git status` is clean on main at repo root
- [ ] Create a worktree (`git worktree add .worktrees/test-branch`) and verify hooks allow edits/commands inside it
- [ ] Verify hooks block file edits and mutating commands on main when a worktree exists
- [ ] Verify the escape guard blocks `cd` back to repo root from a worktree with uncommitted work

🤖 Generated with [Claude Code](https://claude.com/claude-code)