### PR TITLE
Fix dependabot security alerts for git2 and lru

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # File watching and Git
 notify = "6.1"
-git2 = "0.19"
+git2 = "0.20"
 glob = "0.3"
 dashmap = "6.1"
 

--- a/crates/e2e-tests/Cargo.toml
+++ b/crates/e2e-tests/Cargo.toml
@@ -41,7 +41,7 @@ scip = "0.6"
 protobuf = "3.7"
 
 # Git operations (use git2 instead of shelling out to git CLI)
-git2 = "0.19"
+git2 = "0.20"
 
 # Neo4j driver for graph queries
 neo4rs = "0.8"

--- a/crates/indexer/Cargo.toml
+++ b/crates/indexer/Cargo.toml
@@ -28,7 +28,6 @@ tree-sitter-go = { workspace = true }
 git2 = { workspace = true }
 tracing = { workspace = true }
 async-trait = "0.1"
-lru = "0.12"
 futures = "0.3"
 im = "15.1"
 async-stream = "0.3"

--- a/crates/languages/Cargo.toml
+++ b/crates/languages/Cargo.toml
@@ -31,5 +31,5 @@ serde_yaml = "0.9"
 tokio = { workspace = true }
 criterion = { version = "0.5", features = ["html_reports"] }
 serde_json = { workspace = true }
-git2 = "0.19"
+git2 = "0.20"
 tempfile = "3.14"


### PR DESCRIPTION
## Summary
- Upgrade `git2` 0.19 -> 0.20 to fix RUSTSEC-2026-0008 (Buf struct undefined behavior)
- Remove unused `lru` dependency from indexer crate to resolve GHSA-rhfx-m35p-ff5j (IterMut Stacked Borrows violation)

## Test plan
- [x] `cargo clippy --workspace --all-targets --no-default-features -- -D warnings` passes
- [x] `cargo test --workspace --lib --no-default-features` passes
- [ ] Verify dependabot alerts clear after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)